### PR TITLE
refactor: Refactor AI SDK and MCP provider types, add utility functions and constants

### DIFF
--- a/src/providers/ai-sdk-types.ts
+++ b/src/providers/ai-sdk-types.ts
@@ -1,0 +1,90 @@
+/**
+ * Type definitions for AI SDK provider
+ */
+
+import { LanguageModel, JSONValue } from 'ai';
+
+export interface AiSdkFunctionTool {
+  type: 'function';
+  function: {
+    name: string;
+    description?: string;
+    parameters: Record<string, unknown>;
+  };
+}
+
+export interface ToolCallFunction {
+  name: string;
+  arguments: string | Record<string, unknown>;
+}
+
+export interface ToolCall {
+  id: string;
+  type: 'function';
+  function: ToolCallFunction;
+}
+
+export type AiSdkChatMessageParam =
+  | { role: 'system'; content: string }
+  | {
+      role: 'user' | 'assistant' | 'tool';
+      content: string | null;
+      tool_calls?: ToolCall[];
+      tool_call_id?: string;
+    };
+
+export interface AiSdkChatRequest {
+  model: string;
+  messages: AiSdkChatMessageParam[];
+  temperature?: number;
+  max_tokens?: number;
+  maxTokens?: number;
+  tools?: AiSdkFunctionTool[];
+  tool_choice?: 'auto' | 'none' | { type: 'function'; function: { name: string } };
+  response_format?: { type: 'json_object' };
+  [key: string]: unknown;
+}
+
+export interface Usage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+}
+
+export interface AiSdkChatResponse {
+  message?: {
+    content?: string | null;
+    tool_calls?: ToolCall[];
+  };
+  choices?: Array<{
+    message?: {
+      content?: string | null;
+      tool_calls?: ToolCall[];
+    };
+  }>;
+  text?: string | null;
+  id?: string;
+  model?: string;
+  created?: number;
+  usage?: Usage;
+  [key: string]: unknown;
+}
+
+export interface AiSdkClient {
+  chat: (request: AiSdkChatRequest) => Promise<AiSdkChatResponse>;
+}
+
+export interface GenerateObjectResult {
+  object: unknown;
+}
+
+export interface GenerateObjectOptions {
+  model: LanguageModel;
+  schema: unknown;
+  system?: string;
+  messages: unknown[];
+  temperature?: number;
+  maxOutputTokens?: number;
+}
+
+export type SafeJsonParseResult = JSONValue;

--- a/src/providers/constants.ts
+++ b/src/providers/constants.ts
@@ -1,0 +1,18 @@
+/**
+ * Constants for model providers
+ */
+
+export const VISION_MODEL_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+export const VISION_API_TIMEOUT = 3000; // 3 seconds
+
+export const KNOWN_VISION_MODELS = [
+  'gpt-4-vision-preview',
+  'gpt-4o',
+  'gpt-4o-mini',
+  'claude-sonnet-4',
+  'claude-sonnet-4-20250514',
+  'gemini-2.5-flash',
+  'gemini-2.5-pro'
+] as const;
+
+export type KnownVisionModel = typeof KNOWN_VISION_MODELS[number];

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -12,3 +12,29 @@ export {
   type AiSdkClient,
 } from './ai-sdk';
 
+// Export type definitions for external use
+export type {
+  ProxyConfig,
+  ProxyAgentResult,
+  ClientConfig,
+  JsonSchema,
+  VisionModelInfo,
+  VisionApiResponse,
+  VisionModelCacheEntry
+} from './types';
+
+export type {
+  MCPClient,
+  MCPToolDefinition,
+  MCPClientOptions
+} from './mcp-types';
+
+export type {
+  ToolCall,
+  ToolCallFunction,
+  Usage,
+  GenerateObjectResult,
+  GenerateObjectOptions,
+  SafeJsonParseResult
+} from './ai-sdk-types';
+

--- a/src/providers/mcp-types.ts
+++ b/src/providers/mcp-types.ts
@@ -1,0 +1,61 @@
+/**
+ * Type definitions for MCP (Model Context Protocol) provider
+ */
+
+import { z } from 'zod';
+
+export interface JsonSchema {
+  type?: string;
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  description?: string;
+  enum?: string[];
+  items?: JsonSchema;
+  [key: string]: unknown;
+}
+
+export interface MCPToolDefinition {
+  name: string;
+  description?: string;
+  inputSchema?: JsonSchema;
+}
+
+export interface MCPContentItem {
+  type: string;
+  text?: string;
+  [key: string]: unknown;
+}
+
+export interface MCPToolResponse {
+  content?: MCPContentItem[];
+  [key: string]: unknown;
+}
+
+export interface MCPClient {
+  listTools(): Promise<MCPToolDefinition[]>;
+  callTool(name: string, args: unknown): Promise<string>;
+  close(): Promise<void>;
+}
+
+export interface MCPClientOptions {
+  headers?: Record<string, string>;
+  sessionId?: string;
+  fetch?: typeof fetch;
+  requestInit?: RequestInit;
+}
+
+export interface EventSourceModule {
+  default?: unknown;
+  [key: string]: unknown;
+}
+
+export type ZodSchemaType = z.ZodType<unknown>;
+
+export interface MCPToolConversionResult<Ctx> {
+  schema: {
+    name: string;
+    description: string;
+    parameters: z.ZodObject<Record<string, ZodSchemaType>>;
+  };
+  execute: (args: unknown, ctx: Ctx) => Promise<string>;
+}

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Type definitions for model providers
+ */
+
+export interface ProxyConfig {
+  httpProxy?: string;
+  httpsProxy?: string;
+  noProxy?: string;
+}
+
+export interface ProxyAgentResult {
+  httpAgent?: any; // TunnelAgent type is not properly exported
+}
+
+export interface ClientConfig {
+  baseURL: string;
+  apiKey: string;
+  dangerouslyAllowBrowser: boolean;
+  httpAgent?: any; // TunnelAgent type is not properly exported
+}
+
+export interface JsonSchema {
+  type: string;
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  additionalProperties?: boolean;
+  description?: string;
+  items?: JsonSchema;
+  enum?: string[];
+  [key: string]: unknown;
+}
+
+export interface VisionModelInfo {
+  model_group: string;
+  supports_vision?: boolean;
+}
+
+export interface VisionApiResponse {
+  data?: VisionModelInfo[];
+}
+
+export interface VisionModelCacheEntry {
+  supports: boolean;
+  timestamp: number;
+}

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -1,0 +1,157 @@
+/**
+ * Utility functions for model providers
+ */
+
+import tunnel from 'tunnel';
+import { ProxyAgentResult, ProxyConfig, VisionModelCacheEntry, JsonSchema } from './types.js';
+import { VISION_MODEL_CACHE_TTL, VISION_API_TIMEOUT, KNOWN_VISION_MODELS } from './constants.js';
+
+export function createProxyAgent(hostname?: string, proxyConfig?: ProxyConfig): ProxyAgentResult | undefined {
+  const httpProxy = proxyConfig?.httpProxy || process.env.HTTP_PROXY;
+  const noProxy = proxyConfig?.noProxy || process.env.NO_PROXY;
+
+  if ((hostname && noProxy?.includes(hostname)) || !httpProxy) {
+    return undefined;
+  }
+
+  try {
+    console.log(`[JAF:PROXY] Configuring proxy agents:`);
+    if (httpProxy) console.log(`HTTP_PROXY: ${httpProxy}`);
+    if (noProxy) console.log(`NO_PROXY: ${noProxy}`);
+
+    return {
+      httpAgent: httpProxy ? createTunnelAgent(httpProxy) : undefined,
+    };
+  } catch (error) {
+    console.warn(`[JAF:PROXY] Failed to create proxy agents. Install 'https-proxy-agent' and 'http-proxy-agent' packages for proxy support:`, error instanceof Error ? error.message : String(error));
+    return undefined;
+  }
+}
+
+export const createTunnelAgent = (proxyUrl: string) => {
+  const url = new URL(proxyUrl);
+
+  // Create tunnel agent for HTTPS through HTTP proxy
+  return tunnel.httpsOverHttp({
+    proxy: {
+      host: url.hostname,
+      port: parseInt(url.port)
+    },
+    rejectUnauthorized: false
+  });
+};
+
+const visionModelCache = new Map<string, VisionModelCacheEntry>();
+
+export async function isVisionModel(model: string, baseURL: string): Promise<boolean> {
+  const cacheKey = `${baseURL}:${model}`;
+  const cached = visionModelCache.get(cacheKey);
+
+  if (cached && Date.now() - cached.timestamp < VISION_MODEL_CACHE_TTL) {
+    return cached.supports;
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), VISION_API_TIMEOUT);
+
+    const response = await fetch(`${baseURL}/model_group/info`, {
+      headers: {
+        'accept': 'application/json'
+      },
+      signal: controller.signal
+    });
+
+    clearTimeout(timeoutId);
+
+    if (response.ok) {
+      const data = await response.json() as { data?: Array<{ model_group: string; supports_vision?: boolean }> };
+      const modelInfo = data.data?.find((m) =>
+        m.model_group === model || model.includes(m.model_group)
+      );
+
+      if (modelInfo?.supports_vision !== undefined) {
+        const result = modelInfo.supports_vision;
+        visionModelCache.set(cacheKey, { supports: result, timestamp: Date.now() });
+        return result;
+      }
+    } else {
+      console.warn(`Vision API returned status ${response.status} for model ${model}`);
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.name === 'AbortError') {
+        console.warn(`Vision API timeout for model ${model}`);
+      } else {
+        console.warn(`Vision API error for model ${model}: ${error.message}`);
+      }
+    } else {
+      console.warn(`Unknown error checking vision support for model ${model}`);
+    }
+  }
+
+  const isKnownVisionModel = KNOWN_VISION_MODELS.some(visionModel =>
+    model.toLowerCase().includes(visionModel.toLowerCase())
+  );
+
+  visionModelCache.set(cacheKey, { supports: isKnownVisionModel, timestamp: Date.now() });
+
+  return isKnownVisionModel;
+}
+
+export function zodSchemaToJsonSchema(zodSchema: any): JsonSchema {
+  if (zodSchema._def?.typeName === 'ZodObject') {
+    const properties: Record<string, JsonSchema> = {};
+    const required: string[] = [];
+
+    for (const [key, value] of Object.entries(zodSchema._def.shape())) {
+      properties[key] = zodSchemaToJsonSchema(value);
+      if (typeof value === 'object' && value && 'isOptional' in value && typeof (value as any).isOptional === 'function' && !(value as any).isOptional()) {
+        required.push(key);
+      }
+    }
+
+    return {
+      type: 'object',
+      properties,
+      required: required.length > 0 ? required : undefined,
+      additionalProperties: false
+    };
+  }
+
+  if (zodSchema._def?.typeName === 'ZodString') {
+    const schema: JsonSchema = { type: 'string' };
+    if (zodSchema._def.description) {
+      schema.description = zodSchema._def.description;
+    }
+    return schema;
+  }
+
+  if (zodSchema._def?.typeName === 'ZodNumber') {
+    return { type: 'number' };
+  }
+
+  if (zodSchema._def?.typeName === 'ZodBoolean') {
+    return { type: 'boolean' };
+  }
+
+  if (zodSchema._def?.typeName === 'ZodArray') {
+    return {
+      type: 'array',
+      items: zodSchemaToJsonSchema(zodSchema._def.type as any)
+    };
+  }
+
+  if (zodSchema._def?.typeName === 'ZodOptional') {
+    return zodSchemaToJsonSchema(zodSchema._def.innerType as any);
+  }
+
+  if (zodSchema._def?.typeName === 'ZodEnum') {
+    return {
+      type: 'string',
+      enum: zodSchema._def.values
+    };
+  }
+
+  return { type: 'string', description: 'Unsupported schema type' };
+}


### PR DESCRIPTION
This pull request introduces a significant refactor and modularization of type definitions and utility functions for AI model providers, particularly for the AI SDK and MCP (Model Context Protocol) integrations. The main changes involve moving type definitions into dedicated files, improving type safety, and standardizing schema conversions. This will make the codebase easier to maintain, extend, and use in other parts of the project or externally.

**Type Definitions Modularization and Exports:**

- Created new files `ai-sdk-types.ts` and `mcp-types.ts` to hold all type definitions for the AI SDK and MCP providers, respectively, and updated imports/exports throughout the provider modules to use these centralized types. This enhances maintainability and reusability. [[1]](diffhunk://#diff-8b0727a13301cdbafea82e4a172b6684f5137fda207c24e34176b71f0bfb79beR1-R90) [[2]](diffhunk://#diff-c32534a2ff016b5fab73953144532459f141b26e140f426ac096f57ae6583e12R1-R61) [[3]](diffhunk://#diff-5432f74d37e649ff4891dffb5290e4f0566d123ac49356a8456c70be0da29449L16-R46) [[4]](diffhunk://#diff-02f1c3ebe6d316e5ba4b3e230f74bad3bd0a6e9efd8cea1ecdad22a80b1a6c6cL7-R23) [[5]](diffhunk://#diff-488ab83f0a405c2ee9bfabd985cc3c87d94d25635829e3b4d6f92d508ac65bc9R15-R40)

**AI SDK Provider Improvements:**

- Refactored the AI SDK provider to use the new type definitions, improving type safety and clarity. Removed inline type definitions in favor of imports from `ai-sdk-types.ts`.
- Improved the `generateObject` logic to use strongly typed options and results, and cleaned up schema conversion.

**MCP Provider Improvements:**

- Refactored the MCP provider to use types from `mcp-types.ts`, improving type safety for tool definitions, content items, and client interfaces.
- Improved JSON schema to Zod schema conversion, ensuring correct typing and handling of enums and arrays. [[1]](diffhunk://#diff-02f1c3ebe6d316e5ba4b3e230f74bad3bd0a6e9efd8cea1ecdad22a80b1a6c6cL275-R308) [[2]](diffhunk://#diff-02f1c3ebe6d316e5ba4b3e230f74bad3bd0a6e9efd8cea1ecdad22a80b1a6c6cL311-R319) [[3]](diffhunk://#diff-02f1c3ebe6d316e5ba4b3e230f74bad3bd0a6e9efd8cea1ecdad22a80b1a6c6cL328-R335) [[4]](diffhunk://#diff-02f1c3ebe6d316e5ba4b3e230f74bad3bd0a6e9efd8cea1ecdad22a80b1a6c6cL342-R352)
- Standardized handling of tool responses and tool listing across all MCP client implementations (STDIO, SSE, HTTP). [[1]](diffhunk://#diff-02f1c3ebe6d316e5ba4b3e230f74bad3bd0a6e9efd8cea1ecdad22a80b1a6c6cL42-R49) [[2]](diffhunk://#diff-02f1c3ebe6d316e5ba4b3e230f74bad3bd0a6e9efd8cea1ecdad22a80b1a6c6cL58-R67) [[3]](diffhunk://#diff-02f1c3ebe6d316e5ba4b3e230f74bad3bd0a6e9efd8cea1ecdad22a80b1a6c6cL99-R110) [[4]](diffhunk://#diff-02f1c3ebe6d316e5ba4b3e230f74bad3bd0a6e9efd8cea1ecdad22a80b1a6c6cL130-R137) [[5]](diffhunk://#diff-02f1c3ebe6d316e5ba4b3e230f74bad3bd0a6e9efd8cea1ecdad22a80b1a6c6cL146-R155) [[6]](diffhunk://#diff-02f1c3ebe6d316e5ba4b3e230f74bad3bd0a6e9efd8cea1ecdad22a80b1a6c6cL233-R240) [[7]](diffhunk://#diff-02f1c3ebe6d316e5ba4b3e230f74bad3bd0a6e9efd8cea1ecdad22a80b1a6c6cL249-R258)

**Provider Utility and Constants Improvements:**

- Added a new `constants.ts` file for shared model provider constants, such as vision model cache TTL, API timeout, and known vision models.
- Updated `model.ts` to use shared proxy and utility functions, removing redundant proxy agent code and improving clarity. [[1]](diffhunk://#diff-b8de2e22e543dc3c921e3f0bceff94127c2ff5ed1c75b32ebdd7ffcb891d9c1aL2-R12) [[2]](diffhunk://#diff-b8de2e22e543dc3c921e3f0bceff94127c2ff5ed1c75b32ebdd7ffcb891d9c1aL77-R40)

**Exports for External Use:**

- Updated provider module exports to make all relevant types available for external use, improving integration and type sharing across the codebase.

These changes collectively improve code organization, type safety, and extensibility for AI model provider integrations.