### PR TITLE
fix: add missing package subpath entrypoints

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,7 @@
+export * from './types.js';
+export * from './engine.js';
+export * from './tracing.js';
+export * from './errors.js';
+export * from './tool-results.js';
+export * from './agent-as-tool.js';
+export * from './websearch/index.js';

--- a/src/memory/factory.ts
+++ b/src/memory/factory.ts
@@ -1,14 +1,14 @@
-import { 
-  MemoryProvider, 
-  MemoryProviderConfig, 
-  InMemoryConfig, 
-  RedisConfig, 
+import {
+  MemoryProvider,
+  MemoryProviderConfig,
+  InMemoryConfig,
+  RedisConfig,
   PostgresConfig,
   createMemoryConnectionError
-} from './types';
-import { createInMemoryProvider } from './providers/in-memory';
-import { createRedisProvider } from './providers/redis';
-import { createPostgresProvider } from './providers/postgres';
+} from './types.js';
+import { createInMemoryProvider } from './providers/in-memory.js';
+import { createRedisProvider } from './providers/redis.js';
+import { createPostgresProvider } from './providers/postgres.js';
 
 /**
  * Create a memory provider from configuration

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -1,0 +1,5 @@
+export * from './types.js';
+export * from './factory.js';
+export * from './providers/in-memory.js';
+export * from './providers/redis.js';
+export * from './providers/postgres.js';

--- a/src/memory/providers/in-memory.ts
+++ b/src/memory/providers/in-memory.ts
@@ -1,4 +1,4 @@
-import { Message, TraceId } from '../../core/types';
+import type { Message, TraceId } from '../../core/types.js';
 import {
   MemoryProvider,
   ConversationMemory,
@@ -9,7 +9,7 @@ import {
   createFailure,
   createMemoryNotFoundError,
   createMemoryStorageError
-} from '../types';
+} from '../types.js';
 import { safeConsole } from '../../utils/logger.js';
 
 /**

--- a/src/memory/providers/postgres.ts
+++ b/src/memory/providers/postgres.ts
@@ -1,4 +1,4 @@
-import { Message, TraceId } from '../../core/types';
+import type { Message, TraceId } from '../../core/types.js';
 import {
   MemoryProvider,
   ConversationMemory,
@@ -11,7 +11,7 @@ import {
   createMemoryNotFoundError,
   createMemoryStorageError,
   ConversationStatus
-} from '../types';
+} from '../types.js';
 import { safeConsole } from '../../utils/logger.js';
 
 // PostgreSQL client interface - compatible with pg, postgres.js, etc.

--- a/src/memory/providers/redis.ts
+++ b/src/memory/providers/redis.ts
@@ -1,4 +1,4 @@
-import { Message, TraceId } from '../../core/types';
+import type { Message, TraceId } from '../../core/types.js';
 import {
   MemoryProvider,
   ConversationMemory,
@@ -10,7 +10,7 @@ import {
   createMemoryConnectionError,
   createMemoryNotFoundError,
   createMemoryStorageError
-} from '../types';
+} from '../types.js';
 import { safeConsole } from '../../utils/logger.js';
 
 // Redis client interface - compatible with ioredis, node-redis, etc.

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { Message, TraceId, RunId } from '../core/types';
+import type { Message, TraceId, RunId } from '../core/types.js';
 
 // Conversation status types
 export type ConversationStatus = 

--- a/src/policies/index.ts
+++ b/src/policies/index.ts
@@ -1,0 +1,2 @@
+export * from './validation.js';
+export * from './handoff.js';


### PR DESCRIPTION
## Summary
- add the missing `core`, `memory`, and `policies` source entrypoints that are already declared as package subpath exports
- use explicit `.js` relative imports in the new ESM entrypoints and memory provider import chain so the packed package can load in Node ESM consumers

## Why
The published package advertises these subpaths:

- `@juspay-jaf/jaf/core`
- `@juspay-jaf/jaf/memory`
- `@juspay-jaf/jaf/policies`

but `@juspay-jaf/jaf@0.1.46` does not ship `dist/core/index.js`, `dist/memory/index.js`, or `dist/policies/index.js`, so clean consumer imports fail with `ERR_MODULE_NOT_FOUND`.

## Validation
- `corepack pnpm run build`
- `corepack pnpm run typecheck`
- `corepack pnpm run lint`
- `git diff --check`
- packed the fixed checkout with `npm pack --pack-destination ... --json --ignore-scripts`
- installed the packed tarball in a clean temp consumer and verified:
  - `import('@juspay-jaf/jaf/core')`
  - `import('@juspay-jaf/jaf/memory')`
  - `import('@juspay-jaf/jaf/policies')`

I also reproduced the current published-package failure in a clean temp consumer before this patch.
